### PR TITLE
Added vendor- and device id for Via Rhine III

### DIFF
--- a/minix/drivers/net/vt6105/vt6105.conf
+++ b/minix/drivers/net/vt6105/vt6105.conf
@@ -7,6 +7,7 @@ service vt6105
                 IRQCTL          # 19
                 DEVIO           # 21
         ;
+        pci device      1106:3053;
         pci device      1106:3106;
         ipc
                 SYSTEM pm rs log tty ds vm


### PR DESCRIPTION
The device id added is used by ALIX boards.
